### PR TITLE
Fix constructor中的window.UFINDER_CONFIG被覆盖的问题

### DIFF
--- a/_src/core/finder.js
+++ b/_src/core/finder.js
@@ -1,13 +1,13 @@
 var Finder = UF.Finder = UF.createClass('Finder', {
     constructor: function (options) {
-        this._options = $.extend(window.UFINDER_CONFIG || {}, options);
+        this._options = $.extend({}, window.UFINDER_CONFIG || {}, options);
         this.setDefaultOptions(UF.defaultOptions);
         this._initEvents();
         this._initSelection();
         this._initFinder();
         this._initShortcutKey();
         this._initModules();
-
+        window.UFINDER_CONFIG = $.extend(this._options, window.UFINDER_CONFIG || {}, options);
         this.fire('finderready');
     },
     _initFinder: function () {


### PR DESCRIPTION
我的这个做法应该比较丑陋，鉴于初始化的过程不可交换而且各个个属性不能为空，所以$.extend的第一个参数改为{}，以保留window.UFINDER_CONFIG，最终再覆盖回去，并同步更新window.UFINDER_CONFIG。
